### PR TITLE
Chore: Use GATEWAY instead of bills service in env vars

### DIFF
--- a/apps/ui/src/vite.config.ts
+++ b/apps/ui/src/vite.config.ts
@@ -9,7 +9,7 @@ const config: UserConfig = {
 	server: {
 		proxy: {
 			// https://stackoverflow.com/questions/64677212/how-to-configure-proxy-in-vite
-			'/graphql': `${process.env.BILLS_SERVICE}/graphql`
+			'/graphql': `${process.env.GATEWAY}/graphql`
 		}
 	}
 };


### PR DESCRIPTION
## impact surface
- apps/ui - v0.2.0-chore-use-gateway-url-in-ui.1
