### PR TITLE
Fix: Use string for billId instead of UUID

### DIFF
--- a/apps/ui/src/src/routes/bills/+page.svelte
+++ b/apps/ui/src/src/routes/bills/+page.svelte
@@ -14,7 +14,7 @@
     $: billByIdQuery = queryStore({
         client: $urql,
         query: gql`
-            query billById($billId: UUID!) {
+            query billById($billId: String!) {
                 billById(id: $billId) {
                     id
                     name
@@ -85,7 +85,7 @@
             {#if $billByIdQuery.data.billById.payments.length == 0}
                 <p>we don't see any payments made for this bill. 😞</p>
             {:else}
-                <h2>payments</h2>
+                <h2>past payments</h2>
                 {#each $billByIdQuery.data.billById.payments as payment}
                     <p>
                         {#if payment.amount}


### PR DESCRIPTION
## impact surface
- apps/ui - v0.2.0-improv-ui-cleanup-post-move-to-nocodb.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the bill query parameter to accept strings for enhanced compatibility.
- **Style**
	- Changed the heading to "Past Payments" for clarity on the bills page when viewing payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->