### PR TITLE
Chore: Go back using history on click of cancel button on bill addition page

### DIFF
--- a/apps/ui/src/src/routes/bills/add/+page.svelte
+++ b/apps/ui/src/src/routes/bills/add/+page.svelte
@@ -78,7 +78,7 @@
       backgroundColor="#d96c59"
       rounded={true}
       on:click={() => {
-        goto('/');
+        window.history.back();
       }}
     />
     <!-- {#if !isAddingBill} -->


### PR DESCRIPTION
## impact surface
- apps/ui - v0.2.0-chore-ui-go-back-on-cancel-click-bills-page.1
