### PR TITLE
chore: bump ui to 0.2.3

### DIFF
--- a/apps/ui/k8s/values.yaml
+++ b/apps/ui/k8s/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/payobills/apps/ui
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.2"
+  tag: "0.2.3"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## impact surface
- apps/ui - v0.3.25
