### PR TITLE
Chore: Update dotnet dockerfile to include API project as main build

### DIFF
--- a/common/docker/dotnet-svc.prod.dockerfile
+++ b/common/docker/dotnet-svc.prod.dockerfile
@@ -12,7 +12,7 @@ COPY src ./
 
 ARG TARGETARCH
 # RUN dotnet restore
-RUN dotnet publish -c Release --self-contained -a $TARGETARCH -o out
+RUN dotnet publish -c Release --self-contained -a $TARGETARCH -o out API/API.csproj
 
 # build runtime image
 


### PR DESCRIPTION
## impact surface
- apps/bills - v0.4.87
- apps/files - v0.2.87
- apps/payments - v0.3.87
- apps/payments-deprecated - v0.4.87
- apps/transaction-parser - v0.4.87
- apps/transaction-syncer - v0.4.87
- apps/ui - v0.3.87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Dockerfile to explicitly target the API project for publishing, enhancing clarity and reducing ambiguity in multi-project environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->