### PR TITLE
Fix(UI): Use PaidAt attribute to show transaction dates

### DIFF
--- a/apps/ui/k8s/values.yaml
+++ b/apps/ui/k8s/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/payobills/apps/ui
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.43"
+  tag: "0.2.44"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/apps/ui/src/src/lib/recent-transactions.svelte
+++ b/apps/ui/src/src/lib/recent-transactions.svelte
@@ -43,7 +43,7 @@
     if (!ApexCharts) return;
 
     const orderedData = transactions.sort((a: any, b: any) => {
-      return new Date(a.backDate).getTime() - new Date(b.backDate).getTime();
+      return new Date(a.paidAt).getTime() - new Date(b.paidAt).getTime();
     });
 
     let allData = orderedData.map((p: any) => {
@@ -52,7 +52,7 @@
           day: "2-digit",
           month: "short",
           year: "2-digit",
-        }).format(new Date(p.backDate).getTime()),
+        }).format(new Date(p.paidAt).getTime()),
         y: p.amount,
         note: `${p.amount}`,
       };
@@ -194,7 +194,7 @@
             <span>Unknown</span>
           {/if}
           <span class="paid-on"
-            >{formatRelativeDate(new Date(transaction.backDate))}</span
+            >{formatRelativeDate(new Date(transaction.paidAt))}</span
           >
         </div>
         {#if transaction.amount !== null}

--- a/apps/ui/src/src/lib/stores/payment-form.ts
+++ b/apps/ui/src/src/lib/stores/payment-form.ts
@@ -5,7 +5,7 @@ export const paymentForm = writable({
       billId: null,
       amount: null,
       billMonthYear: null,
-      backDate: null,
+      paidAt: null,
       notes: null
     },
     calculatedValues: {

--- a/apps/ui/src/src/routes/timeline/+page.svelte
+++ b/apps/ui/src/src/routes/timeline/+page.svelte
@@ -55,7 +55,7 @@
             id
             amount
             merchant
-            backDate
+            paidAt
             tags
           }
           pageInfo {

--- a/apps/ui/src/src/routes/transaction/[id]/+page.svelte
+++ b/apps/ui/src/src/routes/transaction/[id]/+page.svelte
@@ -38,7 +38,7 @@
             id
             amount
             merchant
-            backDate
+            paidAt
             transactionText
             tags
             parseStatus
@@ -133,7 +133,7 @@
           />
         </div>
         <div class="transaction-detail">
-          {formatRelativeDate(new Date(transaction.backDate))} • {new Intl.DateTimeFormat(
+          {formatRelativeDate(new Date(transaction.paidAt))} • {new Intl.DateTimeFormat(
             "en-GB",
             {
               year: "2-digit",
@@ -143,7 +143,7 @@
               minute: "2-digit",
               second: "2-digit",
             }
-          ).format(new Date(transaction.backDate))}
+          ).format(new Date(transaction.paidAt))}
         </div>
       </section>
       <section class="content">
@@ -194,7 +194,7 @@
           bind:value={$transactionForm.data.amount}
         />
         <div class="transaction-detail">
-          {formatRelativeDate(new Date(transaction.backDate))} • {new Intl.DateTimeFormat(
+          {formatRelativeDate(new Date(transaction.paidAt))} • {new Intl.DateTimeFormat(
             "en-GB",
             {
               year: "2-digit",
@@ -204,7 +204,7 @@
               minute: "2-digit",
               second: "2-digit",
             }
-          ).format(new Date(transaction.backDate))}
+          ).format(new Date(transaction.paidAt))}
         </div>
       </section>
       <section class="content">

--- a/apps/ui/src/src/routes/transactions/[year]/[month]/+page.svelte
+++ b/apps/ui/src/src/routes/transactions/[year]/[month]/+page.svelte
@@ -30,7 +30,7 @@
             id
             amount
             merchant
-            backDate
+            paidAt
             tags
           }
           pageInfo {


### PR DESCRIPTION
closes #223

## impact surface
- apps/ui - v0.2.139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated transaction date handling to use `paidAt` instead of `backDate` across multiple components
	- Improved date-based transaction sorting and display

- **Chores**
	- Bumped UI application image version from `0.2.43` to `0.2.44`

- **Bug Fixes**
	- Corrected transaction date representation in timeline, transaction details, and monthly views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->