### PR TITLE
Feat(transaction-parser): Parse transaction even if BackDate string is unavailable

### DIFF
--- a/apps/transaction-parser/src/main.rs
+++ b/apps/transaction-parser/src/main.rs
@@ -111,6 +111,7 @@ async fn parse_transaction(
         Ok(date) => {
             println!("Parsed date: {:?}", date);
             parsed_date_string = date.clone().to_rfc3339();
+            changes.insert("BackDate".to_string(), Value::Str(parsed_date_string));
         }
         Err(_) => {
             match DateTime::parse_from_rfc3339(record.back_date_string.clone().unwrap().as_str()) {
@@ -125,7 +126,6 @@ async fn parse_transaction(
         }
     }
 
-    changes.insert("BackDate".to_string(), Value::Str(parsed_date_string));
 
     if record.bills.as_ref().unwrap().name.to_string() == String::from("AMEX") {
         let re = Regex::new(


### PR DESCRIPTION
## impact surface
- apps/transaction-parser - v0.4.162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved transaction date parsing logic to ensure "BackDate" is only added when a valid date is successfully parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->