### PR TITLE
Feat(Transaction-Parser): Use `billType` field on transaction for parsing instead of bill name

### DIFF
--- a/apps/transaction-parser/src/main.rs
+++ b/apps/transaction-parser/src/main.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 use std::{error::Error, str::FromStr};
 use tokio;
 
+const BILL_TYPE_AMEX: &str = "Amex";
+const BILL_TYPE_SAVINGS_ACCOUNT: &str = "SavingsAccount";
+const BILL_TYPE_TESTING: &str = "Testing";
+
 #[derive(Serialize, Deserialize)]
 struct PageInfo {
     #[serde(rename = "totalRows")]
@@ -72,7 +76,7 @@ struct Transaction {
     #[serde(rename = "ParseStatus")]
     parse_status: Option<String>,
     #[serde(rename = "BillType")]
-    billType: String,
+    bill_type: String,
 }
 
 enum Value {
@@ -131,7 +135,7 @@ async fn parse_transaction(
         }
     }
 
-    if record.billType == String::from("Amex") {
+    if record.bill_type == BILL_TYPE_AMEX {
         let re = Regex::new(
             r"(\w+): You've spent (\w+) (\d+\,?\d+.\d+) on your AMEX card .* at (.*)\s*on",
         )
@@ -167,7 +171,7 @@ async fn parse_transaction(
                 Value::Str("FailedV1".to_string()),
             );
         }
-    } else if record.billType == String::from("SavingsAccount") {
+    } else if record.bill_type == BILL_TYPE_SAVINGS_ACCOUNT {
         // println!("trying to parse SB");
         // let re = Regex::new(r"(\w+): You've spent (\w+) (\d+\.\d+) on your AMEX card .* at (.*)\s*on")
         let re = Regex::new(
@@ -203,7 +207,7 @@ async fn parse_transaction(
                 Value::Str("FailedV1".to_string()),
             );
         }
-    } else if record.billType == String::from("Testing") {
+    } else if record.bill_type == BILL_TYPE_TESTING {
         println!("Parsing for test bill");
         let re = Regex::new(
             r"(\w+): You've spent (\w+) (\d+\,?\d+.\d+) on your AMEX card .* at (.*)\s*on",

--- a/apps/transaction-parser/src/main.rs
+++ b/apps/transaction-parser/src/main.rs
@@ -71,6 +71,8 @@ struct Transaction {
     notes: Option<String>,
     #[serde(rename = "ParseStatus")]
     parse_status: Option<String>,
+    #[serde(rename = "BillType")]
+    billType: String,
 }
 
 enum Value {
@@ -129,7 +131,7 @@ async fn parse_transaction(
         }
     }
 
-    if record.bills.as_ref().unwrap().name.to_string() == String::from("AMEX") {
+    if record.billType == String::from("Amex") {
         let re = Regex::new(
             r"(\w+): You've spent (\w+) (\d+\,?\d+.\d+) on your AMEX card .* at (.*)\s*on",
         )
@@ -165,7 +167,7 @@ async fn parse_transaction(
                 Value::Str("FailedV1".to_string()),
             );
         }
-    } else if record.bills.as_ref().unwrap().name.to_string() == String::from("SB Account") {
+    } else if record.billType == String::from("SavingsAccount") {
         // println!("trying to parse SB");
         // let re = Regex::new(r"(\w+): You've spent (\w+) (\d+\.\d+) on your AMEX card .* at (.*)\s*on")
         let re = Regex::new(
@@ -201,7 +203,7 @@ async fn parse_transaction(
                 Value::Str("FailedV1".to_string()),
             );
         }
-    } else if record.bills.unwrap().name.to_string() == String::from("Test Bill") {
+    } else if record.billType == String::from("Testing") {
         println!("Parsing for test bill");
         let re = Regex::new(
             r"(\w+): You've spent (\w+) (\d+\,?\d+.\d+) on your AMEX card .* at (.*)\s*on",


### PR DESCRIPTION
## impact surface
- apps/transaction-parser - v0.4.166
