### PR TITLE
Improv(bills-parser): Only parse AMEX bill statements

### DIFF
--- a/apps/bills-parser/src/API/NocoDBBill.cs
+++ b/apps/bills-parser/src/API/NocoDBBill.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+public class NocoDBBill
+{
+    public long Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int? BillingDate { get; set; }
+    public int? PayByDate { get; set; }
+    public int? LatePayByDate { get; set; }
+    public bool IsEnabled { get; set; } = false;
+
+    public string? Type { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [JsonIgnore]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    private DateTime updatedAt;
+
+    [JsonPropertyName("updatedAt")]
+    public string UpdatedAtString
+    {
+        get => updatedAt.ToString("O");
+        set
+        {
+            updatedAt = string.IsNullOrWhiteSpace(value) ? CreatedAt : DateTime.Parse(value);
+            UpdatedAt = updatedAt;
+        }
+    }
+}

--- a/apps/bills-parser/src/API/Program.cs
+++ b/apps/bills-parser/src/API/Program.cs
@@ -72,7 +72,7 @@ class Program
           var bill = await nocodb.GetRecordByIdAsync<NocoDBBill>(billId, nocoDbBaseName, "bills", "*")
               ?? throw new Exception("Bill not found");
 
-          if (bill.Type is not "AMEX") return;
+          if (bill.Type is not "Amex") return;
 
           var fileUrl = fileRecord.Files.ElementAt(0).SignedPath;
           using var httpClient = new HttpClient();


### PR DESCRIPTION
## impact surface
- apps/bills-parser - v0.4.236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for bill records with enhanced tracking of bill details, including dates, type, and status.
- **Bug Fixes**
  - Improved handling of file processing by ensuring only records with valid correlation IDs and of the correct bill type are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->