### PR TITLE
Feat(Files): Expose mimeType and extension fields on File

### DIFF
--- a/apps/files/k8s/values.yaml
+++ b/apps/files/k8s/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: ghcr.io/payobills/apps/files
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.6"
+  tag: "0.2.7"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/apps/files/src/file.resolver.js
+++ b/apps/files/src/file.resolver.js
@@ -2,15 +2,25 @@ module.exports = {
     getFile: ({ nocoDbClient }) => async (file) => {
         const projectId = process.env.NOCODB_PROJECT_ID || "payobills";
         const tableId = process.env.NOCODB_FILES_TABLE_ID || "files";
+
         const record = await nocoDbClient.getRecord(
             projectId,
             tableId,
             file.id
         );
+
+        /**
+         * @type {String} filePath is the path to the file in NocoDB.
+         */
+        const filePath = record.Files[0]?.path || "";
+        const extension = (filePath.search(/\./) !== -1) ? filePath.split(".").pop() : ""
+
         return {
             id: record.Id,
             downloadPath: `/files/${file.id}`,
             fileName: record.Files?.[0]?.title || null,
+            extension,
+            mimeType: record.Files?.[0]?.mimetype,
             createdAt: record.CreatedAt,
             updatedAt: record.UpdatedAt || null,
         };

--- a/apps/files/src/index.js
+++ b/apps/files/src/index.js
@@ -59,6 +59,8 @@ type File @key(fields: "id") {
   """
   id: ID!
   downloadPath: String
+  mimeType: String!
+  extension: String!
   fileName: String
   createdAt: DateTimeISO!
   updatedAt: DateTimeISO


### PR DESCRIPTION
## impact surface
- apps/files - v0.2.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new fields to the File entity, allowing users to view the file's MIME type and extension in the interface.

- **Chores**
  - Updated the container image version used in deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->