### PR TITLE
Fix(Files): Use correct mimetype field to determine extension

### DIFF
--- a/apps/files/k8s/values.yaml
+++ b/apps/files/k8s/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: ghcr.io/payobills/apps/files
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.7"
+  tag: "0.2.8"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/apps/files/src/get-file.route.js
+++ b/apps/files/src/get-file.route.js
@@ -32,7 +32,7 @@ const getFile = ({ nocoDbClient }) => {
             return;
         }
 
-        const mimeType = fileRecord.Files?.[0]?.mimeType || 'application/pdf';
+        const mimeType = fileRecord.Files?.[0]?.mimetype || 'application/pdf';
         const fileExtension = `.${mimeType.split('/').pop()}` || '';
         const url = `${nocoDbClient.getBaseUrl()}/${signedNocodbPath}`
         const fileStream = await axios.get(url, { responseType: "stream" });


### PR DESCRIPTION
## impact surface
- apps/files - v0.2.253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected MIME type extraction for files to ensure accurate Content-Type headers in file downloads.

- **Chores**
  - Updated the container image version used in deployments to 0.2.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->