### PR TITLE
Feat(Transaction-Parser): `POST /api/parses/:transaction_id` API to parse a transaction

### DIFF
--- a/apps/transaction-parser/Cargo.lock
+++ b/apps/transaction-parser/Cargo.lock
@@ -304,6 +304,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1618,7 @@ dependencies = [
 name = "payobills"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "chrono",
  "clap",
  "csv",
@@ -2082,6 +2138,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,6 +2494,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/apps/transaction-parser/Cargo.toml
+++ b/apps/transaction-parser/Cargo.toml
@@ -20,6 +20,7 @@ notion = "0.6.0"
 chrono = "0.4.38"
 jiff = "0.1.24"
 isahc = "1.7.2"
+axum = { version = "0.6", features = ["json"] }
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/apps/transaction-parser/src/api/mod.rs
+++ b/apps/transaction-parser/src/api/mod.rs
@@ -1,0 +1,10 @@
+use axum::{routing::*, *};
+use api::parses;
+
+pub fn create_router() -> Router {
+    Router::new()
+        .merge(
+            Router::new()
+                .route("/api/parses/:transactionId", post(parses::parse_handler))
+        )
+}

--- a/apps/transaction-parser/src/api/mod.rs
+++ b/apps/transaction-parser/src/api/mod.rs
@@ -1,10 +1,12 @@
-use axum::{routing::*, *};
-use api::parses;
+use axum::{routing::*};
 
-pub fn create_router() -> Router {
-    Router::new()
-        .merge(
-            Router::new()
-                .route("/api/parses/:transactionId", post(parses::parse_handler))
-        )
+use crate::api::parses::post_new_parse_handler;
+
+mod parses;
+
+pub(crate) fn create_router() -> Router {
+    Router::new().merge(Router::new().route(
+        "/api/parses/:transaction_id",
+        post(move |transaction_id| post_new_parse_handler(transaction_id)),
+    ))
 }

--- a/apps/transaction-parser/src/api/parses.rs
+++ b/apps/transaction-parser/src/api/parses.rs
@@ -5,5 +5,33 @@ pub(crate) async fn post_new_parse_handler(Path(transaction_id): Path<String>) -
     // Here you would implement the logic to handle the parsing of the transaction
     // For now, we will just return a placeholder response
     // format!("Parsing transaction with ID: {}", transaction_id)
-    Json(json!({ "data": transaction_id }))
+    let nocodb_env = crate::payobills::transaction_parser::NocoDBEnv {
+        base_url: std::env::var("NOCODB__BASE_URL").expect("NOCODB__BASE_URL must be set"),
+
+        base_name_payobills: String::from("payobills"),
+
+        table_name_payobills_transactions: String::from("transactions"), // std::env::var("NOCODB_TABLE_NAME").expect("NOCODB_TABLE_NAME must be set")
+
+        base_name_currencies: std::env::var("NOCODB__BASE_NAME__CURRENCIES")
+            .expect("NOCODB__BASE_NAME__CURRENCIES must be set"),
+
+        table_name_currencies_historical: std::env::var(
+            "NOCODB__TABLE_NAME__CURRENCIES__HISTORICAL",
+        )
+        .expect("NOCODB__TABLE_NAME__CURRENCIES__HISTORICAL must be set"),
+
+        table_name_currencies_currencies: std::env::var(
+            "NOCODB__TABLE_NAME__CURRENCIES__CURRENCIES",
+        )
+        .expect("NOCODB__TABLE_NAME__CURRENCIES__CURRENCIES must be set"),
+
+        api_key: std::env::var("NOCODB__INTEGRATION_TOKEN")
+            .expect("NOCODB__INTEGRATION_TOKEN must be set"),
+    };
+
+    let res =
+        crate::payobills::transaction_parser::parse_transaction_by_id(nocodb_env, transaction_id)
+            .await;
+
+    Json(json!({ "message": "Transaction parsed successfully"}))
 }

--- a/apps/transaction-parser/src/api/parses.rs
+++ b/apps/transaction-parser/src/api/parses.rs
@@ -29,8 +29,7 @@ pub(crate) async fn post_new_parse_handler(Path(transaction_id): Path<String>) -
             .expect("NOCODB__INTEGRATION_TOKEN must be set"),
     };
 
-    let res =
-        crate::payobills::transaction_parser::parse_transaction_by_id(nocodb_env, transaction_id)
+    let _ = crate::payobills::transaction_parser::parse_transaction_by_id(nocodb_env, transaction_id)
             .await;
 
     Json(json!({ "message": "Transaction parsed successfully"}))

--- a/apps/transaction-parser/src/api/parses.rs
+++ b/apps/transaction-parser/src/api/parses.rs
@@ -1,0 +1,9 @@
+use axum::{extract::Path, response::Json};
+use serde_json::{json, Value};
+
+pub(crate) async fn post_new_parse_handler(Path(transaction_id): Path<String>) -> Json<Value> {
+    // Here you would implement the logic to handle the parsing of the transaction
+    // For now, we will just return a placeholder response
+    // format!("Parsing transaction with ID: {}", transaction_id)
+    Json(json!({ "data": transaction_id }))
+}

--- a/apps/transaction-parser/src/cli/mod.rs
+++ b/apps/transaction-parser/src/cli/mod.rs
@@ -1,0 +1,29 @@
+pub(crate) async fn cli() {
+    let nocodb_env = crate::payobills::transaction_parser::NocoDBEnv {
+        base_url: std::env::var("NOCODB__BASE_URL").expect("NOCODB__BASE_URL must be set"),
+
+        base_name_payobills: String::from("payobills"),
+
+        table_name_payobills_transactions: String::from("transactions"), // std::env::var("NOCODB_TABLE_NAME").expect("NOCODB_TABLE_NAME must be set")
+
+        base_name_currencies: std::env::var("NOCODB__BASE_NAME__CURRENCIES")
+            .expect("NOCODB__BASE_NAME__CURRENCIES must be set"),
+
+        table_name_currencies_historical: std::env::var(
+            "NOCODB__TABLE_NAME__CURRENCIES__HISTORICAL",
+        )
+        .expect("NOCODB__TABLE_NAME__CURRENCIES__HISTORICAL must be set"),
+
+        table_name_currencies_currencies: std::env::var(
+            "NOCODB__TABLE_NAME__CURRENCIES__CURRENCIES",
+        )
+        .expect("NOCODB__TABLE_NAME__CURRENCIES__CURRENCIES must be set"),
+
+        api_key: std::env::var("NOCODB__INTEGRATION_TOKEN")
+            .expect("NOCODB__INTEGRATION_TOKEN must be set"),
+    };
+
+    crate::payobills::transaction_parser::process_transactions(nocodb_env.clone())
+        .await
+        .expect("Unable to parse transactions");
+}

--- a/apps/transaction-parser/src/cli/mod.rs
+++ b/apps/transaction-parser/src/cli/mod.rs
@@ -1,4 +1,6 @@
-pub(crate) async fn cli() {
+use std::{error::Error, future::Future};
+
+pub(crate) fn cli() -> impl Future<Output = Result<(), Box<(dyn Error)>>> {
     let nocodb_env = crate::payobills::transaction_parser::NocoDBEnv {
         base_url: std::env::var("NOCODB__BASE_URL").expect("NOCODB__BASE_URL must be set"),
 
@@ -23,7 +25,12 @@ pub(crate) async fn cli() {
             .expect("NOCODB__INTEGRATION_TOKEN must be set"),
     };
 
-    crate::payobills::transaction_parser::process_transactions(nocodb_env.clone())
-        .await
-        .expect("Unable to parse transactions");
+    return crate::payobills::transaction_parser::process_transactions(nocodb_env.clone());
+        // .await
+        // .map_err(|e| {
+        //     eprintln!("Error processing transactions: {}", e);
+        //     std::process::exit(1);
+        // });
+        // .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
+        // .expect("Unable to parse transactions");
 }

--- a/apps/transaction-parser/src/main.rs
+++ b/apps/transaction-parser/src/main.rs
@@ -1,34 +1,9 @@
 use tokio;
 pub mod payobills;
+pub mod cli;
 
 #[tokio::main]
 async fn main() {
 
-    let nocodb_env = payobills::transaction_parser::NocoDBEnv {
-        base_url: std::env::var("NOCODB__BASE_URL").expect("NOCODB__BASE_URL must be set"),
-
-        base_name_payobills: String::from("payobills"),
-
-        table_name_payobills_transactions: String::from("transactions"), // std::env::var("NOCODB_TABLE_NAME").expect("NOCODB_TABLE_NAME must be set")
-
-        base_name_currencies: std::env::var("NOCODB__BASE_NAME__CURRENCIES")
-            .expect("NOCODB__BASE_NAME__CURRENCIES must be set"),
-
-        table_name_currencies_historical: std::env::var(
-            "NOCODB__TABLE_NAME__CURRENCIES__HISTORICAL",
-        )
-        .expect("NOCODB__TABLE_NAME__CURRENCIES__HISTORICAL must be set"),
-
-        table_name_currencies_currencies: std::env::var(
-            "NOCODB__TABLE_NAME__CURRENCIES__CURRENCIES",
-        )
-        .expect("NOCODB__TABLE_NAME__CURRENCIES__CURRENCIES must be set"),
-
-        api_key: std::env::var("NOCODB__INTEGRATION_TOKEN")
-            .expect("NOCODB__INTEGRATION_TOKEN must be set"),
-    };
-
-    payobills::transaction_parser::process_transactions(nocodb_env.clone())
-        .await
-        .expect("Unable to parse transactions");
+    cli::cli().await;
 }

--- a/apps/transaction-parser/src/main.rs
+++ b/apps/transaction-parser/src/main.rs
@@ -5,26 +5,36 @@ pub mod cli;
 pub mod payobills;
 
 #[derive(Debug, Clone, Parser)]
-#[command(version, about, long_about = None)]
+#[command(about, long_about = None)]
 struct Args {
-    #[arg(name = "sub_command")]
-    sub_command: String,
+    #[arg(
+        name = "mode",
+        default_value = "cli",
+        help = "Mode to run, either 'api' or 'cli'"
+    )]
+    mode: String,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = Args::parse();
 
-    if matches.sub_command == String::from("api") {
+    if matches.mode == String::from("api") {
         println!("Starting API server at 0.0.0.0:3000");
 
         let address = String::from("0.0.0.0:3000");
         return axum::Server::bind(&address.parse().unwrap())
-        .serve(crate::api::create_router().into_make_service())
-        .await
-        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
+            .serve(crate::api::create_router().into_make_service())
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
+    } else if matches.mode == String::from("cli") {
+        return crate::cli::cli().await;
     } else {
-        return crate::cli::cli()
-        .await;
+        {
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Unknown mode specified. Use 'api' or 'cli'.",
+            )));
+        }
     }
 }

--- a/apps/transaction-parser/src/main.rs
+++ b/apps/transaction-parser/src/main.rs
@@ -5,36 +5,35 @@ pub mod cli;
 pub mod payobills;
 
 #[derive(Debug, Clone, Parser)]
-#[command(about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Args {
-    #[arg(
-        name = "mode",
-        default_value = "cli",
-        help = "Mode to run, either 'api' or 'cli'"
-    )]
-    mode: String,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Clone, clap::Subcommand)]
+enum Commands {
+    Api,
+    Cli,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = Args::parse();
 
-    if matches.mode == String::from("api") {
-        println!("Starting API server at 0.0.0.0:3000");
+    match matches.command {
+        Commands::Api => {
+            let address =
+                std::env::var("SERVER_ADDRESS").unwrap_or_else(|_| "0.0.0.0:31004".to_string());
+            println!("Starting API server at {}", address);
 
-        let address = String::from("0.0.0.0:3000");
-        return axum::Server::bind(&address.parse().unwrap())
-            .serve(crate::api::create_router().into_make_service())
-            .await
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
-    } else if matches.mode == String::from("cli") {
-        return crate::cli::cli().await;
-    } else {
-        {
-            return Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Unknown mode specified. Use 'api' or 'cli'.",
-            )));
+            return axum::Server::bind(&address.parse()?)
+                .serve(crate::api::create_router().into_make_service())
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
+        }
+        Commands::Cli => {
+            return crate::cli::cli().await.map_err(|e| e as Box<dyn std::error::Error>);
         }
     }
 }

--- a/apps/transaction-parser/src/main.rs
+++ b/apps/transaction-parser/src/main.rs
@@ -1,9 +1,30 @@
-use tokio;
-pub mod payobills;
+use clap::Parser;
+
+pub mod api;
 pub mod cli;
+pub mod payobills;
+
+#[derive(Debug, Clone, Parser)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(name = "sub_command")]
+    sub_command: String,
+}
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let matches = Args::parse();
 
-    cli::cli().await;
+    if matches.sub_command == String::from("api") {
+        println!("Starting API server at 0.0.0.0:3000");
+
+        let address = String::from("0.0.0.0:3000");
+        return axum::Server::bind(&address.parse().unwrap())
+        .serve(crate::api::create_router().into_make_service())
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
+    } else {
+        return crate::cli::cli()
+        .await;
+    }
 }

--- a/apps/transaction-parser/src/payobills/transaction_parser.rs
+++ b/apps/transaction-parser/src/payobills/transaction_parser.rs
@@ -589,6 +589,29 @@ where
     Ok(response)
 }
 
+pub async fn parse_transaction_by_id(nocodb_env: NocoDBEnv, transaction_id: String) -> Result<(), Box<dyn Error>> {
+    let mut map = HeaderMap::new();
+    map.insert("xc-token", nocodb_env.api_key.parse().unwrap());
+
+    let url: String = format!(
+        "{}/api/v1/db/data/nc/{}/{}/{}",
+        nocodb_env.base_url,
+        nocodb_env.base_name_payobills,
+        nocodb_env.table_name_payobills_transactions,
+        transaction_id
+    );
+
+    let response = reqwest::Client::new()
+        .get(url)
+        .headers(map)
+        .send()
+        .await?
+        .json::<Transaction>()
+        .await?;
+
+    parse_transaction(response, nocodb_env).await
+}
+
 pub async fn process_transactions(nocodb_env: NocoDBEnv) -> Result<(), Box<dyn Error>> {
     // let mut offset = 0;
     let mut parse_more = true;


### PR DESCRIPTION
## impact surface
- apps/transaction-parser - 0.5.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an HTTP API endpoint for parsing transactions, accessible via POST requests.
  * Introduced a command-line interface (CLI) for processing transactions, configurable via environment variables.
  * Enabled selection between running the HTTP API server or the CLI through a command-line argument.

* **Refactor**
  * Updated the application startup to use command-line argument parsing for mode selection.
  * Improved error handling and configuration loading for both API and CLI modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->