### PR TITLE
Feat(Payments): Publish RabbitMQ event when parseStatus is set to `NotStarted`

### DIFF
--- a/apps/payments/k8s/values.yaml
+++ b/apps/payments/k8s/values.yaml
@@ -41,6 +41,13 @@ pod:
         name: nocodb-token
   - name: NocoDBOptions__BaseUrl
     value: http://nocodb.homelab.svc.cluster.local:8080
+  - name: EVENT_QUEUE_CONNECTION_STRING
+    valueFrom:
+      secretKeyRef:
+        key: connection-string
+        name: rabbitmq
+  - name: EVENT_QUEUE_NAME
+    value: 'payobills.transaction-parsing'
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/apps/payments/k8s/values.yaml
+++ b/apps/payments/k8s/values.yaml
@@ -41,12 +41,12 @@ pod:
         name: nocodb-token
   - name: NocoDBOptions__BaseUrl
     value: http://nocodb.homelab.svc.cluster.local:8080
-  - name: EVENT_QUEUE_CONNECTION_STRING
+  - name: RabbitMQOptions__ConnectionString
     valueFrom:
       secretKeyRef:
         key: connection-string
         name: rabbitmq
-  - name: EVENT_QUEUE_NAME
+  - name: TransactionParser__RequestParsingQueueName
     value: 'payobills.transaction-parsing'
 
 podSecurityContext: {}

--- a/apps/payments/src/API/API.csproj
+++ b/apps/payments/src/API/API.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Data.Contracts\Data.Contracts.csproj" />
     <ProjectReference Include="..\Services\Services.csproj" />
     <ProjectReference Include="..\NocoDB\NocoDB.csproj" />
+    <ProjectReference Include="..\RabbitMQ\RabbitMQ.csproj" />
   </ItemGroup>
 
 </Project>

--- a/apps/payments/src/API/Program.cs
+++ b/apps/payments/src/API/Program.cs
@@ -45,17 +45,6 @@ builder.Services.AddSingleton<IMapper>((_) =>
 
 builder.Services.AddSingleton<RabbitMQService>();
 
-// builder.Services.AddSingleton<>(async (_) =>
-// {
-//   var factory = new ConnectionFactory
-//   {
-//     Uri = new Uri(builder.Configuration.GetValue<string>("EVENT_QUEUE_CONNECTION_STRING") ?? string.Empty)
-//   };
-
-//   var connection = await factory.CreateConnectionAsync();
-//   return await connection.CreateChannelAsync();
-// });
-
 builder.Services
   .AddGraphQLServer()
   .DisableIntrospection(false)

--- a/apps/payments/src/API/Program.cs
+++ b/apps/payments/src/API/Program.cs
@@ -2,6 +2,8 @@ using Payobills.Payments.Services.Contracts;
 using Payobills.Payments.Services;
 using Payobills.Payments.NocoDB;
 using AutoMapper;
+using RabbitMQ.Client;
+using Payobills.Payments.RabbitMQ;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -19,6 +21,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // options
 builder.Services.Configure<NocoDBOptions>(builder.Configuration.GetRequiredSection(nameof(NocoDBOptions)));
+builder.Services.Configure<RabbitMQOptions>(builder.Configuration.GetRequiredSection(nameof(RabbitMQOptions)));
 
 // bills
 builder.Services.AddSingleton<HttpClient>();
@@ -39,6 +42,19 @@ builder.Services.AddSingleton<IMapper>((_) =>
 
   return new Mapper(config);
 });
+
+builder.Services.AddSingleton<RabbitMQService>();
+
+// builder.Services.AddSingleton<>(async (_) =>
+// {
+//   var factory = new ConnectionFactory
+//   {
+//     Uri = new Uri(builder.Configuration.GetValue<string>("EVENT_QUEUE_CONNECTION_STRING") ?? string.Empty)
+//   };
+
+//   var connection = await factory.CreateConnectionAsync();
+//   return await connection.CreateChannelAsync();
+// });
 
 builder.Services
   .AddGraphQLServer()

--- a/apps/payments/src/RabbitMQ/RabbitMQ.csproj
+++ b/apps/payments/src/RabbitMQ/RabbitMQ.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Payobills.Payments.NocoDB</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Services.Contracts\Services.Contracts.csproj" />
+    <ProjectReference Include="..\Data.Contracts\Data.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
+  </ItemGroup>
+</Project>

--- a/apps/payments/src/RabbitMQ/RabbitMQ.csproj
+++ b/apps/payments/src/RabbitMQ/RabbitMQ.csproj
@@ -3,12 +3,11 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>Payobills.Payments.NocoDB</RootNamespace>
+    <RootNamespace>Payobills.Payments.RabbitMQ</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Services.Contracts\Services.Contracts.csproj" />
-    <ProjectReference Include="..\Data.Contracts\Data.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/payments/src/RabbitMQ/RabbitMQ.sln
+++ b/apps/payments/src/RabbitMQ/RabbitMQ.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RabbitMQ", "RabbitMQ.csproj", "{90E7E94D-DA0E-8D91-2279-153E69E9CD9D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{90E7E94D-DA0E-8D91-2279-153E69E9CD9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90E7E94D-DA0E-8D91-2279-153E69E9CD9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90E7E94D-DA0E-8D91-2279-153E69E9CD9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90E7E94D-DA0E-8D91-2279-153E69E9CD9D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6CFD60A3-77C3-4F46-A05C-45141E8C240B}
+	EndGlobalSection
+EndGlobal

--- a/apps/payments/src/RabbitMQ/RabbitMQOptions.cs
+++ b/apps/payments/src/RabbitMQ/RabbitMQOptions.cs
@@ -1,0 +1,6 @@
+namespace Payobills.Payments.RabbitMQ;
+
+public record RabbitMQOptions
+{
+    public required string ConnectionString { get; set; }
+}

--- a/apps/payments/src/RabbitMQ/RabbitMQService.cs
+++ b/apps/payments/src/RabbitMQ/RabbitMQService.cs
@@ -1,0 +1,61 @@
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Payobills.Payments.Services.Contracts;
+using System.Text.Json.Serialization;
+using RabbitMQ.Client;
+
+namespace Payobills.Payments.RabbitMQ;
+
+public class RabbitMQService
+{
+  private readonly RabbitMQOptions rabbitMQOptions;
+  private  IChannel channel;
+  private  IConnection connection;
+
+  public RabbitMQService(
+    IOptions<RabbitMQOptions> rabbitMQOptions
+  )
+  {
+    this.rabbitMQOptions = rabbitMQOptions.Value;
+  }
+
+  private async Task createRabbitMQChannelAsync()
+  {
+    if (channel is not null && connection is not null)
+    {
+      return; // Channel already created
+    }
+
+    var factory = new ConnectionFactory()
+    {
+      Uri = new Uri(rabbitMQOptions.ConnectionString)
+    };
+    this.connection = await factory.CreateConnectionAsync();
+    this.channel = await connection.CreateChannelAsync();
+
+  }
+
+  public async Task PublishMessageAsync(string queueName, string marshalledMessageString)
+  {
+    if (string.IsNullOrEmpty(queueName))
+    {
+      throw new ArgumentException("Queue name cannot be null or empty.", nameof(queueName));
+    }
+
+    if (marshalledMessageString == null)
+    {
+      throw new ArgumentNullException(nameof(marshalledMessageString), "Message cannot be null.");
+    }
+
+    await this.createRabbitMQChannelAsync();
+
+    this.channel.BasicPublishAsync(
+          string.Empty,
+          routingKey: queueName,
+          body: Encoding.UTF8.GetBytes(marshalledMessageString)
+        );
+  }
+}

--- a/apps/payments/src/Services.Contracts/DTOs/TransactionUpdateDTO.cs
+++ b/apps/payments/src/Services.Contracts/DTOs/TransactionUpdateDTO.cs
@@ -9,6 +9,7 @@ namespace Payobills.Payments.Services.Contracts.DTOs
         public string? Merchant { get; set; }
         public string? Currency { get; set; }
         public double? Amount { get; set; }
+        public string? ParseStatus { get; set; }
         public string? Notes { get { return notes; } set { notes = value ?? string.Empty; } }
         private string notes = string.Empty;
         public string? BackDateString { get; set; } = string.Empty;

--- a/apps/payments/src/Services/Services.csproj
+++ b/apps/payments/src/Services/Services.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Services.Contracts\Services.Contracts.csproj" />
     <ProjectReference Include="..\Data.Contracts\Data.Contracts.csproj" />
     <ProjectReference Include="..\NocoDB\NocoDB.csproj" />
+    <ProjectReference Include="..\RabbitMQ\RabbitMQ.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/payments/src/Services/TransactionsNocoDBService.cs
+++ b/apps/payments/src/Services/TransactionsNocoDBService.cs
@@ -128,7 +128,7 @@ public class TransactionsNocoDBService : ITransactionsService
             updateDTO,
             payloadSerializeOptions);
 
-        if (transactionUpdateResult.ParseStatus == "NotParsed")
+        if (transactionUpdateResult.ParseStatus == "NotStarted")
         {
             await rabbitMQService.PublishMessageAsync(
                             "payobills.transaction-parsing",

--- a/apps/payments/src/Services/TransactionsNocoDBService.cs
+++ b/apps/payments/src/Services/TransactionsNocoDBService.cs
@@ -5,6 +5,7 @@ using Payobills.Payments.Services.Contracts;
 using Payobills.Payments.NocoDB;
 using HotChocolate.Data.Sorting;
 using Payobills.Payments.Services.Contracts.DTOs;
+using Payobills.Payments.RabbitMQ;
 
 namespace Payobills.Payments.Services;
 
@@ -12,13 +13,18 @@ public class TransactionsNocoDBService : ITransactionsService
 {
     private readonly NocoDBClientService nocoDBClientService;
     private readonly IMapper mapper;
+    private readonly RabbitMQService rabbitMQService;
 
     public const string TRANSACTIONS_NOCODB_FIELDS = "*";
 
-    public TransactionsNocoDBService(NocoDBClientService nocoDBClientService, IMapper mapper)
+    public TransactionsNocoDBService(
+        NocoDBClientService nocoDBClientService,
+        RabbitMQService rabbitMQService,
+        IMapper mapper)
     {
         this.nocoDBClientService = nocoDBClientService;
         this.mapper = mapper;
+        this.rabbitMQService = rabbitMQService;
     }
 
     public async Task<IEnumerable<TransactionDTO>> GetTransactionsAsync(SortInputType<TransactionDTO> _, TransactionFiltersInput? filters = null!)
@@ -121,6 +127,17 @@ public class TransactionsNocoDBService : ITransactionsService
             "transactions",
             updateDTO,
             payloadSerializeOptions);
+
+        if (transactionUpdateResult.ParseStatus == "NotParsed")
+        {
+            await rabbitMQService.PublishMessageAsync(
+                            "payobills.transaction-parsing",
+                            JsonSerializer.Serialize(new
+                            {
+                                TransactionId = transactionUpdateResult.Id,
+                            })
+                        );
+        }
 
         var mappedTransactionDTO = new TransactionDTO(transactionUpdateResult);
         return mappedTransactionDTO;


### PR DESCRIPTION
## impact surface
- apps/payments - 0.5.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated RabbitMQ messaging into the payments application, enabling event notifications when certain transaction updates occur.
  * Added support for publishing messages to a queue when a transaction's parse status is set to "NotStarted".
  * Introduced new environment variable settings for event queue integration.
  * Added a new property, ParseStatus, to transaction update data.

* **Chores**
  * Updated project dependencies and configuration to support RabbitMQ integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->