### PR TITLE
Chore: Use latest LTS node.js for svelte static site dockerfile

### DIFF
--- a/common/docker/svelte-static-full.prod.dockerfile
+++ b/common/docker/svelte-static-full.prod.dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=20.11.1
 
-FROM node:${NODE_VERSION}-alpine AS build-env
+FROM node:22.19.0-alpine AS build-env
 WORKDIR /app
 
 COPY src/package*.json ./


### PR DESCRIPTION
## impact surface
No services changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized build environment by pinning Node.js Alpine image version for production builds. This improves reproducibility, reduces build variability across environments, and enhances supply chain transparency and security. No functional changes; app behavior and UI remain unchanged. Expect more consistent deployments and easier CI/CD troubleshooting. Configuration variables and runtime settings are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->