### PR TITLE
Feat(UI): Add recent spends tile on timeline

### DIFF
--- a/apps/ui/src/src/lib/recent-transactions.svelte
+++ b/apps/ui/src/src/lib/recent-transactions.svelte
@@ -16,9 +16,19 @@
     },
     []
   ).filter(p => p.paidAt);
+
+  $: todaysDate = new Intl.DateTimeFormat('en-CA').format(new Date());
+
+  $: todaysSpend = filteredTransactions
+    .filter(p => new Intl.DateTimeFormat('en-CA').format(new Date(p.paidAt)) === todaysDate)
+    .reduce((acc, curr) => acc + curr.amount, 0)
+
+
   export let showViewAllCTA = true;
   export let showAllTransactions = false;
+  export let showRecentSpends = false;
   export let showGraph = false;
+  export let showTotalSpend = true;
   export let title: string | undefined = undefined;
   export let totalSpend = 0;
   export let initialShowCount = 5;
@@ -67,8 +77,6 @@
         }
       }
     }
-
-    
 
     let allData = filteredTransactions.map((p: any) => {
       return {
@@ -188,11 +196,30 @@
   {#if showGraph && transactions.length > 0 && ApexCharts}
     <div use:chart={transactions}></div>
 
+    {#if showRecentSpends}
+      
+    <h2 class='recent-spends__title'>Your recent spends</h2>
+<div class='recent-spends__content'>
+    <div class='recent-spends__spend-tile'>
+      <p>Today's spend</p>
+      <p class="recent-spends__spend-amount">₹ {todaysSpend}</p>
+    </div>
+
+
+     <div class='recent-spends__spend-tile'>
+      <p>This month's spend</p>
+      <p class="recent-spends__spend-amount">₹ {totalSpend}</p>
+    </div>
+    </div>
+    
+    {/if}
+
     <p class="disclaimer">
       It might take upto an hour for latest transactions to show up here...
     </p>
   {/if}
 
+{#if showTotalSpend}
   <div class="transaction-card">
     <div class="recent-transaction">
       <div class="non-amount-details">
@@ -206,7 +233,7 @@
       >
     </div>
   </div>
-  <hr />
+  {/if}
 
   {#each showAllTransactions ? filteredTransactions : filteredTransactions.slice(0, initialShowCount) as transaction (transaction.id)}
     <a class="transaction-card" href={`/transaction?id=${transaction.id}`}>
@@ -292,5 +319,31 @@
   .disclaimer {
     font-size: 0.75rem;
     margin-top: 0
+  }
+
+  .recent-spends__title {
+    margin-top: 0;
+  }
+
+  .recent-spends__spend-tile {
+    background-color: #383838;
+    /* margin: .25rem; */
+    column-gap: .25rem;
+    padding: .5rem;
+    border-radius: .5rem;
+    width: 50%;
+  }
+
+  .recent-spends__content {
+    display: flex;
+    flex-direction: row;
+    gap: .5rem;
+    margin-bottom: 1rem;
+  }
+  
+  .recent-spends__spend-amount {
+    font-weight: 900;
+    font-size: 2.25rem;
+    margin: .5rem 0;
   }
 </style>

--- a/apps/ui/src/src/lib/timeline.svelte
+++ b/apps/ui/src/src/lib/timeline.svelte
@@ -50,7 +50,13 @@
 
 <div class="timeline">
   <div class="timeline-data">
-    <RecentTransactions {transactions} showGraph={true} {title} />
+    <RecentTransactions
+      {transactions}
+      showGraph={true}
+      {title}
+      showRecentSpends={true}
+      showTotalSpend={false}
+    />
 
     {#if filteredItems.length > 0}
       <h1 class="title_bill">Your bills</h1>

--- a/apps/ui/src/src/routes/+layout.svelte
+++ b/apps/ui/src/src/routes/+layout.svelte
@@ -106,7 +106,6 @@
     --primary-bg-color: #181818;
     --secondary-bg-color: #bbbbbb;
     --primary-accent-color: #696adb;
-    
   }
 
   .drawer-transparent {

--- a/apps/ui/src/src/routes/+page.svelte
+++ b/apps/ui/src/src/routes/+page.svelte
@@ -14,14 +14,15 @@
   // }
 
   onMount(async () => {
-    // loadAuthFromLocalStorage();
-    // const authState = get(auth);
-    // if (authState !== null)
+    loadAuthFromLocalStorage();
+    const authState = get(auth);
+    if (authState !== null)
     await goto("/timeline");
   });
 </script>
 
 <div class="main">
+  <a href='http://localhost:8084/auth/realms/homelab-sbx/protocol/openid-connect/auth?client_id=e4d1416e-f275-4764-beea-e919c2477a87&redirect_uri=https://localhost:5173/callback&response_type=code&grant_type=authorization_code&scope=openid'>Login</a>
 </div>
 
 <style>


### PR DESCRIPTION
## impact surface
- apps/ui - 0.6.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional “Your recent spends” section showing today’s spend and this month’s total, with configurable visibility.
  - Timeline view updated to support the new recent spends section and selectively show total spend.
  - Improved authentication handling: automatically loads saved session on page load and redirects to the timeline when signed in.
  - Added a Login link that initiates sign-in via the identity provider.

- Style
  - Minor CSS cleanup with no visual or behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->