### PR TITLE
Improv(UI): Remove extra scrollbar from homepage

### DIFF
--- a/apps/ui/src/src/lib/timeline.svelte
+++ b/apps/ui/src/src/lib/timeline.svelte
@@ -149,7 +149,7 @@
   .timeline-data {
     display: flex;
     flex-direction: column;
-    overflow-y: scroll;
+    overflow-y: hidden;
   }
 
   .items {


### PR DESCRIPTION
## impact surface
- apps/ui - 0.6.18

## screenshots
<img height="200" alt="image" src="https://github.com/user-attachments/assets/5c14f52f-d54b-464d-a433-f2798605dbbe" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified timeline component scrolling behavior: the outer container no longer scrolls while inner timeline items remain scrollable for improved navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->