### PR TITLE
Fix(Payments): Transaction does not load after edit due to empty ParseStatus

### DIFF
--- a/apps/payments/src/Data.Contracts/Models/Transaction.cs
+++ b/apps/payments/src/Data.Contracts/Models/Transaction.cs
@@ -34,7 +34,7 @@ public class Transaction
     public string ParseStatus
     {
       get { return parseStatus ?? "NotStarted"; }
-      set { parseStatus = parseStatus; }
+      set { parseStatus = value; }
     }
 
     public DateTime? BackDate { get; set; }


### PR DESCRIPTION
## impact surface
- apps/payments - 0.6.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction date strings now consistently emit ISO 8601 formatted values.
  * Transaction parse status now defaults to "NotStarted" when unset while still accepting updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->