### PR TITLE
Fix(files): Print sdl with `sdl` query param on graphql endpoint

### DIFF
--- a/apps/files/src/index.js
+++ b/apps/files/src/index.js
@@ -2,7 +2,6 @@
 const { ApolloServer } = require('@apollo/server');
 const { expressMiddleware } = require('@as-integrations/express5');
 const { ApolloServerPluginDrainHttpServer } = require('@apollo/server/plugin/drainHttpServer');
-const { printSchema } = require('graphql');
 const { buildSubgraphSchema } = require('@apollo/subgraph');
 const Express = require("express");
 const multer = require('multer');
@@ -120,6 +119,15 @@ input FilesInput {
 
   await apolloServer.start();
 
+  app.get('/graphql', async (req, res, next) => {
+    if (req.query.sdl !== undefined) {
+      const result = await apolloServer.executeOperation({ query: '{ _service { sdl } }' });
+      const sdl = result.body.singleResult?.data?._service?.sdl;
+      return res.type('text/plain').send(sdl);
+    }
+    next();
+  });
+
   app.use(
     '/graphql',
     Express.json(),
@@ -141,3 +149,4 @@ input FilesInput {
 }
 
 main().catch(console.error)
+


### PR DESCRIPTION
## impact surface
- apps/files - 0.6.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GET endpoint support for retrieving the GraphQL schema definition language (SDL) by including the `sdl` query parameter in requests to `/graphql`.

* **Chores**
  * Removed unused package import and improved code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->