### PR TITLE
Chore: bump rust version 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,5 +197,5 @@ jobs:
     with:
       PLZ_SUBCOMMAND: "run"
       PLZ_SUBCOMMAND_ARGS: "${{ needs.ci.outputs.CHANGED_APP_TARGETS }}"
-      ENV_VARS: "{ \"VERSION\":\"0.0.0-pr.${{ github.event.pull_request.number }}\", \"CI\": \"true\", \"EXTRA_ARGS\":\"--push\", \"NODE_VERSION\":\"20.11.1\", \"RUST_VERSION\":\"1.79.0-alpine3.20\", \"DOTNET_VERSION\":\"8.0.404\",\"DOTNET_RUNTIME_VERSION\":\"8.0.3-bookworm-slim\"}"
+      ENV_VARS: "{ \"VERSION\":\"0.0.0-pr.${{ github.event.pull_request.number }}\", \"CI\": \"true\", \"EXTRA_ARGS\":\"--push\", \"NODE_VERSION\":\"20.11.1\", \"RUST_VERSION\":\"1.95.0-alpine3.20\", \"DOTNET_VERSION\":\"8.0.404\",\"DOTNET_RUNTIME_VERSION\":\"8.0.3-bookworm-slim\"}"
 

--- a/.github/workflows/docker_buildx-on-tag-publish.yml
+++ b/.github/workflows/docker_buildx-on-tag-publish.yml
@@ -70,4 +70,4 @@ jobs:
       PLZ_SUBCOMMAND_ARGS: "//apps/${{ needs.tag-checker-job.outputs.APP_NAME }}:docker_buildx"
       APP_NAME: ${{ needs.tag-checker-job.outputs.APP_NAME }}
       VERSION: ${{ needs.tag-checker-job.outputs.VERSION }}
-      ENV_VARS: "{ \"APP_NAME\":\"${{ needs.tag-checker-job.outputs.APP_NAME }}\", \"VERSION\":\"${{ needs.tag-checker-job.outputs.VERSION }}\", \"CI\": \"true\", \"EXTRA_ARGS\":\"--push\", \"NODE_VERSION\":\"20.11.1\", \"RUST_VERSION\":\"1.79.0-alpine3.20\", \"DOTNET_VERSION\":\"8.0.404\",\"DOTNET_RUNTIME_VERSION\":\"8.0.3-bookworm-slim\"}"
+      ENV_VARS: "{ \"APP_NAME\":\"${{ needs.tag-checker-job.outputs.APP_NAME }}\", \"VERSION\":\"${{ needs.tag-checker-job.outputs.VERSION }}\", \"CI\": \"true\", \"EXTRA_ARGS\":\"--push\", \"NODE_VERSION\":\"20.11.1\", \"RUST_VERSION\":\"1.95.0-alpine3.20\", \"DOTNET_VERSION\":\"8.0.404\",\"DOTNET_RUNTIME_VERSION\":\"8.0.3-bookworm-slim\"}"

--- a/.github/workflows/run-plz.yml
+++ b/.github/workflows/run-plz.yml
@@ -14,7 +14,7 @@ on:
         type: string
       ENV_VARS:
         description: "JSON string of environment variables"
-        default: '{ "CI": "true", "EXTRA_ARGS":"--push", "DOTNET_VERSION":"8.0.404","DOTNET_RUNTIME_VERSION":"8.0.3-bookworm-slim", "NODE_VERSION": "20.11.1", "RUST_VERSION": "1.79.0-alpine3.20" }'
+        default: '{ "CI": "true", "EXTRA_ARGS":"--push", "DOTNET_VERSION":"8.0.404","DOTNET_RUNTIME_VERSION":"8.0.3-bookworm-slim", "NODE_VERSION": "20.11.1", "RUST_VERSION": "1.95.0-alpine3.20" }'
         type: string
       PLZ_SUBCOMMAND_ARGS:
         description: "Arguments for plz command"


### PR DESCRIPTION
## impact surface
No services changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain version across CI/CD pipelines to 1.95.0-alpine3.20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->